### PR TITLE
Support haplotype-resolved liftovers

### DIFF
--- a/.github/workflows/CI-blat.yml
+++ b/.github/workflows/CI-blat.yml
@@ -37,10 +37,12 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
 
-      - name: Install Dependencies
+      - name: Install mamba
         run: |
-          chmod a+x ./assets/install.sh
-          assets/install.sh
+          wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh
+          bash Mambaforge.sh -b -p ./mambaforge
+          ./mambaforge/bin/mamba init
+          source ./mambaforge/etc/profile.d/conda.sh 
 
       - name: Run pipeline with test data and minimap2
         run: |

--- a/.github/workflows/CI-blat.yml
+++ b/.github/workflows/CI-blat.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ["23.04.0"]
+        nxf_ver: ["24.04.4"]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/CI-gsa.yml
+++ b/.github/workflows/CI-gsa.yml
@@ -37,10 +37,12 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
 
-      - name: Install Dependencies
+      - name: Install mamba
         run: |
-          chmod a+x ./assets/install.sh
-          assets/install.sh
+          wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh
+          bash Mambaforge.sh -b -p ./mambaforge
+          ./mambaforge/bin/mamba init
+          source ./mambaforge/etc/profile.d/conda.sh 
 
       - name: Run pipeline with test data and minimap2
         run: |

--- a/.github/workflows/CI-gsa.yml
+++ b/.github/workflows/CI-gsa.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ["23.04.0"]
+        nxf_ver: ["24.04.4"]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/CI-lastz.yml
+++ b/.github/workflows/CI-lastz.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ["23.04.0"]
+        nxf_ver: ["24.04.4"]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/CI-lastz.yml
+++ b/.github/workflows/CI-lastz.yml
@@ -37,10 +37,12 @@ jobs:
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
 
-      - name: Install Dependencies
+      - name: Install mamba
         run: |
-          chmod a+x ./assets/install.sh
-          assets/install.sh
+          wget -nv -O Mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh
+          bash Mambaforge.sh -b -p ./mambaforge
+          ./mambaforge/bin/mamba init
+          source ./mambaforge/etc/profile.d/conda.sh 
 
       - name: Run pipeline with test data
         run: |

--- a/.github/workflows/CI-mm2.yml
+++ b/.github/workflows/CI-mm2.yml
@@ -9,15 +9,11 @@ on:
       - 'main'
       - 'dev'
       - '*test'
+      - 'v*'
   pull_request:
   workflow_dispatch:
   release:
     types: [published]
-  # Try run minimap2 also if trying to fix an issue, to ensure
-  # that, overall, things work
-  issues:
-    types:
-      - opened
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/CI-mm2.yml
+++ b/.github/workflows/CI-mm2.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ["23.04.0"]
+        nxf_ver: ["24.04.4"]
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2

--- a/.github/workflows/CI-mm2.yml
+++ b/.github/workflows/CI-mm2.yml
@@ -13,6 +13,11 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  # Try run minimap2 also if trying to fix an issue, to ensure
+  # that, overall, things work
+  issues:
+    types:
+      - opened
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.8.3]
+- Added `--haplotypes` mode, that allows to create liftover files between haplotypes of the same individual with UCSC naming convention 
+
 ## [v1.8.2]
 - `--aligner minimap2` now runs on individual target sequences to reduce the memory footprint and improve performances in large distributed systems
 - updated dependencies (minimap2 v2.26.0, last v1454, crossmap v0.6.4, bedtools v2.31.0, lastz v1.04.22, blat v445)

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ This analysis will run using genome1 and genome2 as source and target, respectiv
 whereas the target will be fragmented in 10Mb chunks overlapping 100Kb. It will use lastz as the aligner using the preset for closely related genomes (near).
 The output files will be copied into the folder my_liftover.
 
+## Frequently asked questions
+
++ _How do I liftover between two haplotypes of the same genome?_ You can lift over positions between haplotypes of the same individual (i.e. having the sequences named `*_hap*` or `*_alt*`) by providing the `--haplotypes` option.
+
 ## Citing nf-LO
 To cite nf-LO, please refer to:
 ```

--- a/docs/chain.md
+++ b/docs/chain.md
@@ -36,3 +36,6 @@ nextflow run evotools/nf-LO --igenome_source GRCh37 \
    --no_netsynt \
    --chainCustom '-minScore=5000 -linearGap=medium'
 ```  
+
+## Haplotype-resolved assemblies
+Normally, the workflow will not liftover positions between haplotype sequences (i.e. having the sequences named `*_hap*` or `*_alt*`). This can cause the workflow to generate empty liftovers when the process only involves sequences with the aforementioned naming, for example when lifting `hap1` to `hap2` of the same individual. To still generate liftovers in such cases, users have to provide the `--haplotypes` option, which will allow the workflow to retain such alignments downstream.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## [v1.8.3]
+- Added `--haplotypes` mode, that allows to create liftover files between haplotypes of the same individual with UCSC naming convention 
 
 ## [v1.8.2]
 - `--aligner minimap2` now runs on individual target sequences to reduce the memory footprint and improve performances in large distributed systems

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, Andrea Talenti'
 author = 'Andrea Talenti'
 
 # The full version, including alpha/beta/rc tags
-release = '1.6.0'
+release = '1.8.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,3 @@
+# Frequently asked questions
+
++ _How do I liftover between two haplotypes of the same genome?_ You can lift over positions between haplotypes of the same individual (i.e. having the sequences named `*_hap*` or `*_alt*`) by providing the `--haplotypes` option.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ User guide
   liftover
   output
   reports
+  faq
   changelog
   citations
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,4 +1,6 @@
 # Changelog
+## [v1.8.3]
+- Added `--haplotypes` mode, that allows to create liftover files between haplotypes of the same individual with UCSC naming convention 
 
 ## [v1.8.2]
 - `--aligner minimap2` now runs on individual target sequences to reduce the memory footprint and improve performances in large distributed systems

--- a/modules/processes/postprocess.nf
+++ b/modules/processes/postprocess.nf
@@ -150,9 +150,10 @@ process chainNet_old{
 
     script:
     if ( params.aligner != "blat" & params.aligner != "nucmer" & params.aligner != "GSAlign")
+    def haplotypes = params.haplotypes ? "-inclHap" : ""
     """
-    chainPreNet ${rawchain} ${twoBitsizeS} ${twoBitsizeT} stdout |
-        chainNet -verbose=0 stdin ${twoBitsizeS} ${twoBitsizeT} stdout /dev/null | netSyntenic stdin netfile.net
+    chainPreNet $${haplotypes} {rawchain} ${twoBitsizeS} ${twoBitsizeT} stdout |
+        chainNet -verbose=0 ${haplotypes} stdin ${twoBitsizeS} ${twoBitsizeT} stdout /dev/null | netSyntenic stdin netfile.net
     netChainSubset -verbose=0 netfile.net ${rawchain} stdout | chainStitchId stdin stdout > liftover.chain
     """
 }
@@ -178,9 +179,10 @@ process chainNet{
     """
 
     script:
+    def haplotypes = params.haplotypes ? "-inclHap" : ""
     """
-    chainPreNet ${rawchain} ${twoBitsizeS} ${twoBitsizeT} stdout |
-        chainNet -verbose=0 stdin ${twoBitsizeS} ${twoBitsizeT} netfile.net /dev/null 
+    chainPreNet ${haplotypes} ${rawchain} ${twoBitsizeS} ${twoBitsizeT} stdout |
+        chainNet ${haplotypes} -verbose=0 stdin ${twoBitsizeS} ${twoBitsizeT} netfile.net /dev/null 
     """
 }
 

--- a/modules/processes/postprocess.nf
+++ b/modules/processes/postprocess.nf
@@ -152,7 +152,7 @@ process chainNet_old{
     if ( params.aligner != "blat" & params.aligner != "nucmer" & params.aligner != "GSAlign")
     def haplotypes = params.haplotypes ? "-inclHap" : ""
     """
-    chainPreNet $${haplotypes} {rawchain} ${twoBitsizeS} ${twoBitsizeT} stdout |
+    chainPreNet ${haplotypes} {rawchain} ${twoBitsizeS} ${twoBitsizeT} stdout |
         chainNet -verbose=0 ${haplotypes} stdin ${twoBitsizeS} ${twoBitsizeT} stdout /dev/null | netSyntenic stdin netfile.net
     netChainSubset -verbose=0 netfile.net ${rawchain} stdout | chainStitchId stdin stdout > liftover.chain
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,6 +17,7 @@ params {
     igenomes_target = false
     distance = 'medium'
     aligner = 'lastz'
+    haplotypes = false
     srcSize = 20000000
     tgtSize = 10000000
     tgtOvlp = 100000
@@ -188,7 +189,7 @@ manifest {
   mainScript      = 'main.nf'
   nextflowVersion = '>=21.10.0'
   defaultBranch   = 'main'
-  version         = '1.8.2'
+  version         = '1.8.3'
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -100,6 +100,7 @@ profiles {
     charliecloud.enabled   = false
     conda.createTimeout = '8 h'
     includeConfig 'conf/conda.config'
+    process.conda = "$projectDir/environment.yml"
     conda.useMamba = params.mamba ? true : false
   }
   docker {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -66,6 +66,10 @@
                     "default": "medium",
                     "enum": ["same", "near", "medium", "far", "balanced", "custom"]
                 },
+                "haplotypes": {
+                    "type": "boolean",
+                    "default": false
+                },
                 "aligner": {
                     "type": "string",
                     "default": "lastz",


### PR DESCRIPTION
Addresses #23 

The workflow currently emits empty liftover files when a user provides sequences with naming `*_hap*` or `*_alt*`. This MR addresses the issue by adding a `--haplotypes` option, that enables to consider these sequences when generating the chain files.